### PR TITLE
t.co-Links aufgelöst

### DIFF
--- a/studies.json
+++ b/studies.json
@@ -3,25 +3,25 @@
         {
             "description": "Gerinnungsstörungen",
             "Tagline": "Beeinflusst das Blut",
-            "link": "https://t.co/8yS0Z7twTS",
+            "link": "https://www.nature.com/articles/s41577-022-00762-9",
             "": ""
         },
         {
             "description": "1 von 8 Personen entwickelt Long Covid",
             "Tagline": "Risiko für Long Covid",
-            "link": "https://t.co/FoUAsHXNnh",
+            "link": "https://theconversation.com/amp/long-covid-why-its-so-hard-to-tell-how-many-people-get-it-188270",
             "": ""
         },
         {
             "description": "Bei Reinfektionen doppelt so hohes Risiko für Krankenhausaufenthalt und Mortalität",
             "Tagline": "Krankenhausaufenthalte",
-            "link": "https://t.co/CSSAt8SVN0",
+            "link": "https://www.researchsquare.com/article/rs-1749502/v1",
             "": ""
         },
         {
             "description": "Entzündungen des Gehirns durch Eintritt der Viren",
             "Tagline": "Covid beeinflusst das Gehirn",
-            "link": "https://t.co/sj5SYeJXEf",
+            "link": "https://www.biorxiv.org/content/10.1101/2022.08.31.505985v1",
             "": ""
         },
         {
@@ -105,19 +105,19 @@
         {
             "description": "Langzeitentzündung des Herzmuskels in über 90% der Fälle",
             "Tagline": "Herzmuskelenzündung",
-            "link": "https://t.co/TjrAJphYCh",
+            "link": "https://www.nature.com/articles/s41591-022-02000-0",
             "": ""
         },
         {
             "description": "Praeklapsiewahrscheinlichkeit steigt an",
             "Tagline": "Schwangerschaft Präklapsie",
-            "link": "https://t.co/9CHoEW2Irs",
+            "link": "https://www.newyorker.com/science/annals-of-medicine/why-a-life-threatening-pregnancy-complication-is-on-the-rise",
             "": ""
         },
         {
             "description": "periphere Neuropatie",
             "Tagline": "Neurologische Schäden",
-            "link": "https://t.co/52ekAKdMa4"
+            "link": "https://pubmed.ncbi.nlm.nih.gov/35915515/"
         }
     ]
 }


### PR DESCRIPTION
Ich habe die Links zu dem Kurz-URL-Dienst t.co aufgelöst und die dahinterstehende URL eingetragen. Dadurch sehen die Nutzer:innen, wohin der Link wirklich geht und sparen den Umweg über Twitter.